### PR TITLE
Update Docs and Service Name Options

### DIFF
--- a/docs/framework-elastic_apm_agent.md
+++ b/docs/framework-elastic_apm_agent.md
@@ -1,11 +1,11 @@
 # Elastic APM Agent Framework
 
-The Elastic APM Agent Framework causes an application to be automatically configured to work with [Elastic APM][]. 
+The Elastic APM Agent Framework causes an application to be automatically configured to work with [Elastic APM][].
 
 <table>
   <tr>
     <td><strong>Detection Criterion</strong></td>
-    <td>Existence of a cf service named `elasticapm` will cause the detection and instantiation of the `ElasticApmAgent` code in the buildpack. 
+    <td>Existence of a single bound Elastic APM service. The existence of an Elastic APM service defined by the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service name, label or tag with <code>elasticapm</code> or <code>elastic-apm</code> as a substring.
   </tr>
   <tr>
     <td><strong>Tags</strong></td>
@@ -16,26 +16,49 @@ Tags are printed to standard output by the buildpack detect script
 
 For more information regarding setup and configuration, please refer to the [Elastic APM with Pivotal Cloud Foundry tutorial][pivotal].
 
+## User-Provided Service
+When binding Elastic APM using a user-provided service, it must have name or tag with `elasticapm` or `elastic-apm` in it. The credential payload can contain the following entries.
+
+| Name | Description
+| ---- | -----------
+| `server_urls` | The URLs for the Elastic APM Server. They must be fully qualified, including protocol (http or https) and port.
+| `secret_token` (Optional)| This string is used to ensure that only your agents can send data to your APM server. Both the agents and the APM server have to be configured with the same secret token. Use if APM Server requires a token.
+| `***`	(Optional) | Any additional entries will be applied as a system property appended to `-Delastic.apm.` to allow full configuration of the agent. See [Configuration of Elastic Agent][].
+
+
+### Creating an Elastic APM USer Provided Service
+Users must provide their own Elastic APM service. A user-provided Elastic APM service must have a name or tag with `elastic-apm` or `elasticapm` in it so that the Elastic APM Agent Framework will automatically configure the application to work with the service.
+
+Example of a minimal configuration:
+
+```
+cf cups my-elastic-apm-service -p '{"server_urls":"https://my-apm-server:8200","secret_token":"my-secret-token"}'
+```
+
+Example of a configuration with additional configuration parameters:
+
+```
+cf cups my-elastic-apm-service -p '{"server_urls":"https://my-apm-server:8200","secret_token":"","server_timeout":"10s","environment":"production"}'
+```
+
+Bind your application to the service using:
+
+`cf bind-service my-app-name my-elastic-apm-service`
+
+or use the `services` block in the application manifest file.
+
+
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
-
-### Create a "elasticapm" Service 
-
-`cf update-user-provided-service elasticapm  -p 'server_urls,secret_token,server_timeout'`
-Enter your systems specific values into the service VCAP. 
-
-Bind your application to this service:  `cf bind-service ApplicationName elasticapm `
-
-When the application pushes/restages, this service will be detected and automatically bind the variables, jar file into the java apps startup. 
-
-### Static configuration of supported versions 
 
 The framework can be configured by modifying the [`config/elastic_apm_agent.yml`][] file in the buildpack fork.  The framework uses the [`Repository` utility support][repositories] and so it supports the [version syntax][] defined there.
 
 | Name | Description
 | ---- | -----------
+| `service_name` | This can be overridden by a `service_name` entry in the credentials payload. If neither are supplied the default is the application_name as specified by Cloud Foundry.
 | `repository_root` | The URL of the Elastic APM repository index ([details][repositories]).
 | `version` | The version of Elastic APM to use. Candidate versions can be found in [this listing][].
+
 
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/elastic_apm_agent.yml`]: ../config/elastic_apm_agent.yml
@@ -43,3 +66,4 @@ The framework can be configured by modifying the [`config/elastic_apm_agent.yml`
 [repositories]: extending-repositories.md
 [this listing]: https://raw.githubusercontent.com/elastic/apm-agent-java/master/cloudfoundry/index.yml
 [version syntax]: extending-repositories.md#version-syntax-and-ordering
+[Configuration of Elastic Agent]: https://www.elastic.co/guide/en/apm/agent/java/current/configuration.html

--- a/lib/java_buildpack/framework/elastic_apm_agent.rb
+++ b/lib/java_buildpack/framework/elastic_apm_agent.rb
@@ -42,7 +42,7 @@ module JavaBuildpack
       #                        application.
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials   = @application.services.find_service(FILTER, [SERVER_URL, SECRET_TOKEN, SERVER_TIMEOUT])['credentials']
+        credentials   = @application.services.find_service(FILTER, [SERVER_URL, SECRET_TOKEN])['credentials']
         java_opts     = @droplet.java_opts
         configuration = {}
 
@@ -58,12 +58,12 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, [SERVER_URL, SERVER_TIMEOUT, SECRET_TOKEN]
+        @application.services.one_service? FILTER, [SERVER_URL, SECRET_TOKEN]
       end
 
       private
 
-      FILTER = /elasticapm/
+      FILTER = /elastic[-]?apm/
 
       BASE_KEY = 'elastic.apm.'
 
@@ -71,16 +71,13 @@ module JavaBuildpack
 
       SECRET_TOKEN = "secret_token"
 
-      SERVER_TIMEOUT = 'server_timeout'
-
       SERVICE_NAME = 'service_name'
 
-      private_constant :FILTER, :SERVER_URL, :SERVER_TIMEOUT, :BASE_KEY, :SECRET_TOKEN
+      private_constant :FILTER, :SERVER_URL, :BASE_KEY, :SECRET_TOKEN
 
       def apply_configuration(credentials, configuration)
         configuration['log_file_name'] = 'STDOUT'
         configuration[SERVER_URL]      = credentials[SERVER_URL]
-        configuration[SERVER_TIMEOUT]  = credentials[SERVER_TIMEOUT]
         configuration[SECRET_TOKEN]    = credentials[SECRET_TOKEN]
         configuration[SERVICE_NAME]    = @application.details['application_name']
       end

--- a/spec/java_buildpack/framework/elastic_apm_agent_spec.rb
+++ b/spec/java_buildpack/framework/elastic_apm_agent_spec.rb
@@ -23,17 +23,17 @@ require 'java_buildpack/util/tokenized_version'
 describe JavaBuildpack::Framework::ElasticApmAgent do
   include_context 'with component help'
 
-  it 'does not detect without elasticapm-n/a service' do
+  it 'does not detect without elastic-apm-n/a service' do
     expect(component.detect).to be_nil
   end
 
   context do
 
     before do
-      allow(services).to receive(:one_service?).with(/elasticapm/, %w[secret_token secret_token]).and_return(true)
+      allow(services).to receive(:one_service?).with(/elastic[-]?apm/, %w[secret_token secret_token]).and_return(true)
     end
 
-    it 'detects with elastic-n/a service' do
+    it 'detects with elastic-apm-n/a service' do
       expect(component.detect).to eq("elastic-apm-agent=#{version}")
     end
 


### PR DESCRIPTION
- Updated Docs
- Updated the Ruby framework to accept elastic-apm or elaticapm also made server timeout optional. 
- Updated the spec to accept elastic-apm or elaticapm (although that was just cut-n-pasta) 
